### PR TITLE
Bumps Flask Login to version compatible with Werkzeug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==2.3.3
 Flask-SQLAlchemy==3.0.5
 Flask-Migrate==4.0.5
-Flask-Login==0.6.2
+Flask-Login==0.6.3
 python-dotenv==1.0.0
 openai==1.97.1
 pytest==7.4.3


### PR DESCRIPTION
I tried to run this and got an error:

```
justindonato@Mac move % cd ..
justindonato@Mac projects % git clone https://github.com/rafeco-etsy/candidly.git
cd candidly

... clipped

justindonato@Mac candidly % clear
justindonato@Mac candidly % pyenv virtualenv candidly
Looking in links: /var/folders/sw/9t9tw6nd7w512gdm94g3t6lm0000gn/T/tmpvlpd2bh4
Requirement already satisfied: pip in /Users/justindonato/.pyenv/versions/candidly/lib/python3.13/site-packages (25.1.1)
justindonato@Mac candidly % source ~/.pyenv/versions/candidly/bin/activate
(candidly) justindonato@Mac candidly % pip install -r requirements.txt

... clipped

❌ Error: Command 'flask db init' returned non-zero exit status 2.
   Error: While importing 'app', an ImportError was raised:

Traceback (most recent call last):
  File "/Users/justindonato/.pyenv/versions/candidly/lib/python3.13/site-packages/flask/cli.py", line 219, in locate_app
    __import__(module_name)
    ~~~~~~~~~~^^^^^^^^^^^^^
  File "/Users/justindonato/projects/candidly/app.py", line 3, in <module>
    from flask_login import login_required, current_user, login_user, logout_user
  File "/Users/justindonato/.pyenv/versions/candidly/lib/python3.13/site-packages/flask_login/__init__.py", line 12, in <module>
    from .login_manager import LoginManager
  File "/Users/justindonato/.pyenv/versions/candidly/lib/python3.13/site-packages/flask_login/login_manager.py", line 33, in <module>
    from .utils import _create_identifier
  File "/Users/justindonato/.pyenv/versions/candidly/lib/python3.13/site-packages/flask_login/utils.py", line 14, in <module>
    from werkzeug.urls import url_decode
ImportError: cannot import name 'url_decode' from 'werkzeug.urls' (/Users/justindonato/.pyenv/versions/candidly/lib/python3.13/site-packages/werkzeug/urls.py)


Usage: flask [OPTIONS] COMMAND [ARGS]...
Try 'flask --help' for help.

Error: No such command 'db'.
❌ Database setup failed
```

Seems like the flask login version is not compatible with the werkzeug version. This bump fixed it for me.

